### PR TITLE
fix: restore site-wide black dark theme + emerald accent

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -3,10 +3,18 @@
 # Documentation: https://docs.hugoblox.com/
 # This file is formatted using YAML syntax - learn more at https://learnxinyminutes.com/docs/yaml/
 
-# Appearance
-appearance:
-  mode: system
-  color: emerald
+# Appearance (HugoBlox v2 theme engine - the legacy 'appearance' key is ignored by blox v0.12+)
+hugoblox:
+  theme:
+    # 'light', 'dark', or 'system' (follows OS preference; navbar toggle overrides per session)
+    mode: system
+    # Built-in 'default' pack for light mode, custom 'black' pack (pure-black bg) for dark mode
+    pack:
+      light: default
+      dark: black
+    # Brand color (restores the previous emerald accent in both modes)
+    colors:
+      primary: emerald
 
 # SEO
 marketing:

--- a/content/_index.md
+++ b/content/_index.md
@@ -19,9 +19,6 @@ sections:
 #        text: Download CV
 #        url: uploads/resume.pdf
     design:
-      css_class: dark
-      background:
-        color: black
       columns: '1'
 #  - block: markdown
 #    content:

--- a/data/themes/black.yaml
+++ b/data/themes/black.yaml
@@ -1,0 +1,42 @@
+# HugoBlox Theme Pack - Black dark mode
+# Same as the built-in 'default' pack but with a pure-black dark background,
+# matching the previous site look. Used as the dark pack via
+# params.yaml: hugoblox.theme.pack.dark = black
+
+hugoblox:
+  meta:
+    format: "hugoblox-theme@1"
+    name: "Black"
+    vendor: "user"
+    version: "1.0.0"
+    license: "MIT"
+
+  type: "dual"
+
+  light:
+    colors:
+      primary: "emerald"
+      secondary: "blue"
+    surfaces:
+      background: "#ffffff"
+      foreground: "#111827"
+      header:
+        background: "#f1f5f9"
+        foreground: "#0f172a"
+      footer:
+        background: "#f3f4f6"
+        foreground: "#0f172a"
+
+  dark:
+    colors:
+      primary: "emerald"
+      secondary: "teal"
+    surfaces:
+      background: "#000000"
+      foreground: "#f8fafc"
+      header:
+        background: "#000000"
+        foreground: "#f8fafc"
+      footer:
+        background: "#000000"
+        foreground: "#e5e7eb"


### PR DESCRIPTION
The new `blox v0.12.0` module ignores the legacy `appearance:` key, so the site fell back to the built-in theme whose dark background is `#0f172a` (dark blue) instead of black, and the emerald brand color was lost. The resume section was separately forced black, making it inconsistent (always black, even in light mode).

This PR makes the whole site follow the dark/light theme consistently, with black in dark mode:
- `params.yaml`: switch to the `hugoblox` v2 theme schema — `mode: system`, `pack: {light: default, dark: black}`, `primary: emerald`.
- `data/themes/black.yaml`: custom dark pack — pure-black (`#000`) background/header/footer, emerald primary.
- `_index.md`: drop the forced `background.color: black`/`css_class: dark` from the resume block so it follows the theme.

Verified locally: light bg `#ffffff`, dark bg `#000000`, primary = emerald-500, resume section consistent with the rest.